### PR TITLE
Add icon for arch pkgs

### DIFF
--- a/package/contents/tools/tools.js
+++ b/package/contents/tools/tools.js
@@ -372,6 +372,12 @@ function makeArchList(updates, all, description) {
          0: "NM",  2: "DE",  4: "LN",  6: "GR",  7: "PR",  8: "DP",
         10: "RQ", 12: "CF", 13: "RP", 14: "IS", 17: "DT", 18: "RN"
     }
+    const setIcon = (packageObj) => execute(
+        `out=$(pacman -Qlq ${packageObj.NM} | grep "^/usr/share/applications/.*.desktop" | head -n 1) && [[ -n "$out" ]] && grep "^Icon=" "$out"`,
+        (cmd, out, err, code) => {
+            if (out) packageObj.IN = out.slice(5).trim()
+        }
+    )
 
     let extendedList = packagesData.map(packageData => {
         packageData = packageData.split('\n').filter(line => line.includes(" : "))
@@ -387,6 +393,7 @@ function makeArchList(updates, all, description) {
             const found = all.find(str => packageObj.NM === str.split(" ")[1])
             packageObj.RE = found ? found.split(" ")[0] : (packageObj.NM.endsWith("-git") ? "devel" : "aur")
             packageObj.LN = packageObj.LN.replace(/\/+$/, '')
+            setIcon(packageObj)
             updates.forEach(str => {
                 const [name, verold, , vernew] = str.split(" ")
                 if (packageObj.NM === name) {


### PR DESCRIPTION
Thanks for your awesome work. I thought the icons are automatically set for all pkgs, and after reading the code I find the icon for arch pkg is the default value now (`apdatifier-package`), so I add some scripts to get the `.desktop` file the pkg owns and find the icon name. 

It works: (The code may have problems about asynchronous callback)

![Screenshot_20250211_142616](https://github.com/user-attachments/assets/ee5cfbe2-664a-4b76-868f-daab4f4221bd)
