### PR TITLE
fix: escape double quotes

### DIFF
--- a/package/contents/tools/sh/widgets
+++ b/package/contents/tools/sh/widgets
@@ -72,7 +72,8 @@ get_package_info() {
     local originName=$(jq -r '.KPlugin.Name' $metadata)
     name=$(echo "$originName" | sed 's/ /-/g; s/.*/\L&/')
 
-    contentId=$(xmllint --xpath "string(//name[text()='$originName']/../id)" $XML)
+    local quotedOriginName='"'$(echo "$originName" | sed 's/"/\\"/g')'"'
+    contentId=$(xmllint --xpath "string(//name[text()=$quotedOriginName]/../id)" "$XML")
     if [[ -z "$contentId" ]]; then
         knsregistry=("plasmoids" "kwinscripts" "kwineffect" "wallpaperplugin")
         for kns in "${knsregistry[@]}"; do


### PR DESCRIPTION
Trying to fix https://github.com/exequtic/apdatifier/issues/81.

I introduced another local variable enclosed with `"` to be used in XPath handling.

Please feel free to correct me since I'm no expert.