### PR TITLE
Patch: Fix spacing bug by eliding overflowing news titles

### DIFF
--- a/package/contents/ui/scrollview/News.qml
+++ b/package/contents/ui/scrollview/News.qml
@@ -23,7 +23,7 @@ ScrollView {
         leftMargin: spacing
         bottomMargin: spacing
 
-        add: Transition { NumberAnimation { properties: "x"; from: 100; duration: Kirigami.Units.longDuration } }
+        // add: Transition { NumberAnimation { properties: "x"; from: 100; duration: Kirigami.Units.longDuration } } NEWS SPACING PATCH
         removeDisplaced: Transition { NumberAnimation { properties: "x,y"; duration: Kirigami.Units.longDuration } }
         remove: Transition { ParallelAnimation {
                 NumberAnimation { property: "opacity"; to: 0; duration: Kirigami.Units.longDuration }
@@ -58,15 +58,13 @@ ScrollView {
                         ColumnLayout {
                             Controls.Label {
                                 Layout.fillWidth: true
-                                wrapMode: Text.NoWrap
-                                elide: Text.ElideRight
+                                wrapMode: Text.WordWrap
                                 text: model.title
                                 font.bold: true
                             }
                             Controls.Label {
                                 Layout.fillWidth: true
-                                wrapMode: Text.NoWrap
-                                elide: Text.ElideRight
+                                wrapMode: Text.WordWrap
                                 text: model.date
                                 opacity: 0.6
                             }
@@ -75,8 +73,7 @@ ScrollView {
                             }
                             Controls.Label {
                                 Layout.fillWidth: true
-                                wrapMode: Text.NoWrap
-                                elide: Text.ElideRight
+                                wrapMode: Text.WordWrap
                                 text: model.article
                             }
                         }

--- a/package/contents/ui/scrollview/News.qml
+++ b/package/contents/ui/scrollview/News.qml
@@ -58,13 +58,15 @@ ScrollView {
                         ColumnLayout {
                             Controls.Label {
                                 Layout.fillWidth: true
-                                wrapMode: Text.WordWrap
+                                wrapMode: Text.NoWrap
+                                elide: Text.ElideRight
                                 text: model.title
                                 font.bold: true
                             }
                             Controls.Label {
                                 Layout.fillWidth: true
-                                wrapMode: Text.WordWrap
+                                wrapMode: Text.NoWrap
+                                elide: Text.ElideRight
                                 text: model.date
                                 opacity: 0.6
                             }
@@ -73,7 +75,8 @@ ScrollView {
                             }
                             Controls.Label {
                                 Layout.fillWidth: true
-                                wrapMode: Text.WordWrap
+                                wrapMode: Text.NoWrap
+                                elide: Text.ElideRight
                                 text: model.article
                             }
                         }


### PR DESCRIPTION
# Summary
This PR partially addresses #127 ("News Boxes have wrong spacing when line wraps around") by removing an animation that apparently causes the issue.

# Changes
- Removed the animation

# Before
- Long text in news wrapped, leading to uneven vertical spacing.
<img width="465" height="488" alt="image" src="https://github.com/user-attachments/assets/48014cdc-eb1d-4892-b277-9e857b62a78d" />

# After
- Correct spacing with wrapping text, no animation