### PR TITLE
Now using config.json with JSON format

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -98,7 +98,7 @@
         <entry name="tabBarTexts" type="bool"><default>true</default></entry>
     </group>
     <group name="Miscellaneous">
-        <entry name="version" type="string"><default>v0</default></entry>
+        <entry name="version" type="string"><default>v2.9.5</default></entry>
         <entry name="timestamp" type="string"><default></default></entry>
         <entry name="configMsg" type="bool"><default>true</default></entry>
         <entry name="rulesMsg" type="bool"><default>true</default></entry>

--- a/package/metadata.json
+++ b/package/metadata.json
@@ -12,7 +12,7 @@
         "Id": "com.github.exequtic.apdatifier",
         "Name": "Apdatifier",
         "EnabledByDefault": false,
-        "Version": "2.9.4",
+        "Version": "2.9.5",
         "License": "MIT",
         "BugReportUrl": "https://github.com/exequtic/apdatifier/issues",
         "Website": "https://github.com/exequtic/apdatifier"


### PR DESCRIPTION
I had a problem in the initialization of the plasmoid, when starting the session, which could be reproduced by executing "plasmashell --replace". It happened because the plasmoid tried to read the config.conf file as if it were a JSON formatted file, which is not the case. The problem as in the writing of the configuration file, which is now renamed to 'config.json' in the same directory and written in JSON format. The old 'config.conf' file may be safely removed.