### PR TITLE
fix(rss): retry curl on DNS failures when fetching news feeds

### DIFF
--- a/package/contents/tools/sh/utils
+++ b/package/contents/tools/sh/utils
@@ -215,7 +215,7 @@ rss() {
 
     for url in "$@"; do
         local rssFile=$(mktemp "$tempDir/XXXXXX.xml")
-        curl -s -o "$rssFile" --connect-timeout 5 --retry 2 --max-time 10 --url "$url" 2>/dev/null
+        curl -s -o "$rssFile" --connect-timeout 5 --retry 3 --retry-delay 1 --retry-all-errors --max-time 10 --url "$url" 2>/dev/null
         xmllint --noout "$rssFile" 2>/dev/null || {
             errors+="$url "
             continue


### PR DESCRIPTION
## Summary

- curl's `--retry` does not retry on DNS resolution failures (exit code 6) by default — only on timeouts and HTTP errors. This causes intermittent "Cannot fetch news" errors on systems without a local DNS cache when the resolver briefly fails.
- Added `--retry-all-errors` to the RSS feed curl call so it retries on all transient errors including DNS failures
- Bumped retries from 2 to 3 and added `--retry-delay 1` for a 1-second pause between attempts

## Context

On systems using NetworkManager without `systemd-resolved` or `dnsmasq`, there is no local DNS cache. Brief DNS resolver hiccups cause the RSS fetch to fail immediately with no retry, producing the "Cannot fetch news" error in the widget. With `--retry-all-errors`, curl will retry these transient DNS failures before giving up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)