### PR TITLE
fix: filter out mirrors with failed curl connections in rank_mirrors()

### DIFF
--- a/package/contents/tools/sh/mirrorlist
+++ b/package/contents/tools/sh/mirrorlist
@@ -34,12 +34,12 @@ rank_mirrors() {
         local exit_code=$?
         local time status
         
-        if [[ $exit_code -eq 28 ]]; then
-            status="Timeout"
+        if [[ $exit_code -ne 0 ]]; then
+            status="Unreachable"
         else
             time="${response%% *}"
             local code="${response##* }"
-            [[ $code -ge 400 || -z "$code" ]] && status="Unreachable"
+            [[ -z "$code" || $code -lt 200 || $code -gt 299 ]] && status="Unreachable"
         fi
         
         if [[ -n "$status" ]]; then


### PR DESCRIPTION
## Summary
- Check for any non-zero curl exit code, not just timeout (28)
- Only accept HTTP 200-299 instead of rejecting >= 400 — catches status `000` from broken mirrors that accept TCP but return no valid HTTP response

Fixes #184

## Test plan
- Set mirrorlist URL to UK (`?country=GB` — `mirror.marcusn.net` is currently broken)
- Refresh mirrorlist via widget
- Verify broken mirrors are excluded from `/etc/pacman.d/mirrorlist`

Tested against real mirrors:
```
Unreachable - https://mirror.marcusn.net/...  (exit=0, response='0.046616 000')
Unreachable - http://mirror.marcusn.net/...   (exit=0, response='0.046763 000')
OK 0.089373s - https://london.mirror.pkgbuild.com/...  (exit=0, response='0.089373 200')
OK 0.083120s - https://archlinux.uk.mirror.allworldit.com/...  (exit=0, response='0.083120 200')
OK 0.095233s - https://mirrors.ukfast.co.uk/...  (exit=0, response='0.095233 200')
```