### PR TITLE
fix: reset upgrade state when work is done, not when terminal closes

### DIFF
--- a/package/contents/tools/sh/upgrade
+++ b/package/contents/tools/sh/upgrade
@@ -23,6 +23,7 @@ run() {
 bin="$sudoBin pacman"; [ "$aur" = true ] && bin=$wrapper
 
 fullSystemUpgrade() {
+    rm -f "$configDir/upgrade_complete"
     startTime=$(date +%s)
     critical_updated=()
     critical_installed=()
@@ -152,6 +153,7 @@ fullSystemUpgrade() {
 }
 
 flatpak_package() {
+    rm -f "$configDir/upgrade_complete"
     printMsg "$UPGRADE_PACKAGE: $2"
     echo
 
@@ -163,6 +165,7 @@ flatpak_package() {
 }
 
 widget_package() {
+    rm -f "$configDir/upgrade_complete"
     printMsg "$UPGRADE_PACKAGE: $2"
     echo
 

--- a/package/contents/tools/sh/utils
+++ b/package/contents/tools/sh/utils
@@ -66,10 +66,13 @@ printMsg() {
 }
 
 printClose() {
+    touch "$configDir/upgrade_complete"
+    trap 'rm -f "$configDir/upgrade_complete"' EXIT INT TERM
     tput civis
     printMsg "$UPGRADE_ENTER"
     read -r
     tput cnorm
+    rm -f "$configDir/upgrade_complete"
     [[ $(basename $terminal) = "yakuake" ]] && qdbusCMD sessions removeSession $(qdbusCMD sessions activeSessionId)
 }
 

--- a/package/contents/tools/tools.js
+++ b/package/contents/tools/tools.js
@@ -192,10 +192,17 @@ function management() {
 
 
 function upgradingState() {
-    const checkProc = `pgrep -f "apdatifier.*upgrade*"`
+    const sentinelFile = configDir + "upgrade_complete"
+    const checkProc = `ps aux | grep "[a]pdatifier/contents/tools/sh/upgrade" > /dev/null && ! [ -f "${sentinelFile}" ] && echo running`
     execute(checkProc, (cmd, out, err, code) => {
-        if (!out) {
-            sts.busy = sts.upgrading = false
+        const state = out.trim() === "running"
+        sts.busy = sts.upgrading = state
+        if (state) {
+            upgradeTimer.start()
+            scheduler.stop()
+            sts.statusMsg = i18n("Upgrade in progress") + "..."
+            sts.statusIco = cfg.ownIconsUI ? "toolbar_upgrade" : "akonadiconsole"
+        } else {
             upgradeTimer.stop()
             execute(bash('utils', "currentVersions"), (cmd, out, err, code) => {
                 if (Error(code, err)) return
@@ -213,12 +220,6 @@ function upgradingState() {
                 setStatusBar()
                 resumeScheduler()
             })
-        } else {
-            scheduler.stop()
-            upgradeTimer.start()
-            sts.busy = sts.upgrading = true
-            sts.statusMsg = i18n("Upgrade in progress") + "..."
-            sts.statusIco = cfg.ownIconsUI ? "toolbar_upgrade" : "akonadiconsole"
         }
     })
 }


### PR DESCRIPTION
## Problem

The widget stays stuck showing the 'Upgrade in progress' spinner (and the scheduler doesn't resume) until the terminal window is manually closed, even though the actual upgrade has finished and 'Press Enter to close' is displayed.

## Root cause

`printClose()` holds the upgrade script process alive with a blocking `read -r`. `upgradingState()` detects completion by grepping `ps aux` for the upgrade script process — which is still alive during the read.

## Fix

Write a sentinel file (`~/.config/apdatifier/upgrade_complete`) at the start of `printClose()`, before the blocking `read`. Change `upgradingState()` to treat the state as 'upgrading' only when the process is running **and** the sentinel is absent. The sentinel is deleted after the user presses Enter (and via a `trap` on INT/TERM for robustness), and also cleared at the start of each upgrade function to handle any stale file from a previous crash.

## Behaviour after fix

- Widget resets immediately when 'Press Enter to close' appears — the terminal window can be left open indefinitely without affecting the widget
- The update check scheduler resumes on its normal schedule regardless of whether the terminal is still open
- No change to terminal UX — 'Press Enter to close' still works exactly as before

## Files changed

- `package/contents/tools/sh/utils` — `printClose()`: write sentinel before blocking read, delete after (+ trap for INT/TERM)
- `package/contents/tools/sh/upgrade` — `fullSystemUpgrade()`, `flatpak_package()`, `widget_package()`: clear stale sentinel on start
- `package/contents/tools/tools.js` — `upgradingState()`: treat state as 'upgrading' only when process running AND sentinel absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)