### PR TITLE
feat: apply pacman IgnorePkg when listing repo and AUR updates

### DIFF
--- a/package/contents/tools/tools.js
+++ b/package/contents/tools/tools.js
@@ -240,6 +240,36 @@ function stopCheck() {
 }
 
 
+function loadIgnorePkgs() {
+    return new Promise(resolve => {
+        if (!cfg.packages || !cfg.packages.pacman) {
+            resolve([])
+            return
+        }
+
+        execute("pacman-conf IgnorePkg", (cmd, out, err, code) => {
+            if (code || !out) {
+                resolve([])
+                return
+            }
+
+            const tokens = out.trim().split(/\s+/).filter(Boolean)
+            const escapeRe = s => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+
+            const patterns = tokens.map(token => {
+                let pat = token.split(/[<>=]/)[0].trim()
+                if (!pat) return null
+                let re = escapeRe(pat)
+                re = re.replace(/\\\*/g, ".*").replace(/\\\?/g, ".")
+                return new RegExp("^" + re + "$")
+            }).filter(Boolean)
+
+            resolve(patterns)
+        })
+    })
+}
+
+
 function checkUpdates() {
     if (sts.upgrading) return
 
@@ -364,9 +394,21 @@ function checkUpdates() {
 
     function merge() {
         const list = keys(archRepos.concat(archAur, flatpak, widgets, firmwares))
-        sts.errors.length > 0 
-            ? runLater(3000, () => isOnline ? finalize(list) : stopCheck())
-            : finalize(list)
+
+        const finish = (finalList) => {
+            sts.errors.length > 0
+                ? runLater(3000, () => isOnline ? finalize(finalList) : stopCheck())
+                : finalize(finalList)
+        }
+
+        loadIgnorePkgs().then(ignorePatterns => {
+            if (!ignorePatterns || ignorePatterns.length === 0) {
+                finish(list)
+            } else {
+                const filtered = list.filter(pkg => !ignorePatterns.some(re => re.test(pkg.NM)))
+                finish(filtered)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

This PR makes Apdatifier respect `IgnorePkg` from `pacman.conf` when listing available updates for both repo and AUR packages.

## Motivation

- Currently, `paru -Qu` does not honour `IgnorePkg` in `pacman.conf` (an upstream behaviour).
- As a result, Apdatifier could show updates for packages that the user explicitly marked as ignored, especially when using `paru`.
- The same configuration should apply consistently regardless of which helper (`pacman`, `yay`, `paru`, `pikaur`) is used.

## Implementation

- Add a small helper that calls `pacman-conf IgnorePkg` and converts the result into match patterns.
- After collecting all updates (repo, AUR, Flatpak, widgets, firmware) and merging them into a single list, filter out any packages whose names match the `IgnorePkg` patterns.
- This filtering happens only at the “display / counting” stage:
  - It does **not** change how upgrades are executed.
  - It simply hides packages that the user has chosen to ignore, keeping the UI consistent with `pacman.conf`.

## Notes / Limitations

- This PR focuses on `IgnorePkg`; `IgnoreGroup` is not handled yet.
- The change also benefits `yay` and other helpers, but it is especially useful as a workaround for the upstream `paru -Qu` behaviour.

## Testing

- Configure `IgnorePkg` in `pacman.conf` (e.g. `make`, `freetype2` and some AUR packages).
- Run Apdatifier with:
  - `wrapper = paru`
  - `wrapper = yay`
- Confirm that:
  - Packages listed in `IgnorePkg` no longer appear in the Apdatifier update list.
  - Other updates are still listed and counted correctly.