### PR TITLE
fix: display close message after non-critical update

### DIFF
--- a/package/contents/tools/sh/upgrade
+++ b/package/contents/tools/sh/upgrade
@@ -147,12 +147,14 @@ fullSystemUpgrade() {
         while true; do
             printQuestion "$UPGRADE_REBOOT"; read -r answer
             case "$answer" in
-                    [Yy]*) sys_reboot; break;;
-                 [Nn]*|"") printClose; break;;
+                    [Yy]*) sys_reboot; exit;;
+                 [Nn]*|"") break;;
                         *)  ;;
             esac
         done
     fi
+
+    printClose
 }
 
 sys_reboot() {


### PR DESCRIPTION
This change fixes a minor regression introduced by #199 that prevented the "Press Enter to close" message from appearing after non-critical updates. Other than that, the core behavior introduced by that PR is preserved.