### PR TITLE
i18n: update German translation

### DIFF
--- a/package/translate/po/de.po
+++ b/package/translate/po/de.po
@@ -1441,7 +1441,7 @@ msgstr "Versionshinweise ansehen"
 
 #: ../contents/ui/representation/Expanded.qml
 msgid "Dismiss"
-msgstr "Ablehnen"
+msgstr "Verwerfen"
 
 #: ../contents/ui/representation/Expanded.qml
 msgid "No internet connection"


### PR DESCRIPTION
## What

Changes the German translation of "Dismiss" from "Ablehnen" to "Verwerfen".

## Why

"Ablehnen" translates to "reject/decline". I only ever stumbled across it after Apdatifier updated itself, in the banner where you can choose whether to visit the changelog. "Verwerfen" fits better there.